### PR TITLE
[FEAT]: cargo clippy integration for static code analysis

### DIFF
--- a/internal/alloweditems/alloweditems.go
+++ b/internal/alloweditems/alloweditems.go
@@ -1,0 +1,17 @@
+package alloweditems
+
+import (
+	"os"
+	"path/filepath"
+
+	Exercise "github.com/42-Short/shortinette/pkg/interfaces/exercise"
+	"github.com/42-Short/shortinette/pkg/logger"
+)
+
+func Execute(exercise Exercise.Exercise) (err error) {
+	if err = os.Remove(filepath.Join("compile-environment", exercise.TurnInDirectory, "Cargo.toml")); err != nil {
+		return err
+	}
+	logger.Info.Printf("no forbidden items/keywords found in %s", exercise.TurnInDirectory+"/"+exercise.TurnInFiles[0])
+	return nil
+}

--- a/internal/alloweditems/alloweditems.go
+++ b/internal/alloweditems/alloweditems.go
@@ -5,13 +5,20 @@ import (
 	"path/filepath"
 
 	Exercise "github.com/42-Short/shortinette/pkg/interfaces/exercise"
-	"github.com/42-Short/shortinette/pkg/logger"
+	"github.com/42-Short/shortinette/pkg/testutils"
 )
 
-func Execute(exercise Exercise.Exercise) (err error) {
-	if err = os.Remove(filepath.Join("compile-environment", exercise.TurnInDirectory, "Cargo.toml")); err != nil {
+func Execute(exercise Exercise.Exercise, clippyTomlAsString string) (err error) {
+	file, err := os.Create(filepath.Join("compile-environment", exercise.TurnInDirectory, ".clippy.toml"))
+	if err != nil {
 		return err
 	}
-	logger.Info.Printf("no forbidden items/keywords found in %s", exercise.TurnInDirectory+"/"+exercise.TurnInFiles[0])
+	if _, err = file.WriteString(clippyTomlAsString); err != nil {
+		return err
+	}
+	workingDirectory := filepath.Join("compile-environment", exercise.TurnInDirectory)
+	if output, err := testutils.RunCommandLine(workingDirectory, "cargo", []string{"clippy", "--", "-D", "warnings"}); err != nil {
+		
+	}
 	return nil
 }

--- a/internal/alloweditems/alloweditems.go
+++ b/internal/alloweditems/alloweditems.go
@@ -3,22 +3,88 @@ package alloweditems
 import (
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 
 	Exercise "github.com/42-Short/shortinette/pkg/interfaces/exercise"
+	"github.com/42-Short/shortinette/pkg/logger"
 	"github.com/42-Short/shortinette/pkg/testutils"
 )
 
-func Execute(exercise Exercise.Exercise, clippyTomlAsString string) (err error) {
-	file, err := os.Create(filepath.Join("compile-environment", exercise.TurnInDirectory, ".clippy.toml"))
+func prependLintLevel(filePath string, lintLevelModifications []string) (err error) {
+	contentAsBytes, err := os.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	contentAsStringSlice := strings.Split(string(contentAsBytes), "\n")
+	for index, line := range contentAsStringSlice {
+		if !strings.HasPrefix(line, "#![") {
+			for _, modification := range lintLevelModifications {
+				contentAsStringSlice = slices.Insert(contentAsStringSlice, index, modification)
+			}
+			break
+		}
+	}
+
+	err = os.WriteFile(filePath, []byte(strings.Join(contentAsStringSlice, "\n")), 0644)
+	if err != nil {
+		return err
+	}
+
+	logger.Info.Printf("content of %s:\n%s", filePath, strings.Join(contentAsStringSlice, "\n"))
+
+	return nil
+}
+
+// Checks for forbidden methods/macros using `cargo clippy`.
+//
+// Args:
+// exercise: `Exercise.Exercise` structure containing the exercise metadata
+//
+// clippyTomlAsString: string representation of the `.clippy.toml file which should dictate the lint rules`
+//
+// lintLevelModifications: slice of strings representing the lint level modifications you want to add
+//
+// Example Usage:
+//   - I want to ban `std::ptr::read` and `std::println`
+//   - I also want to remove the documentation linter, which would fail students
+//     for wrong indentation in comments (https://rust-lang.github.io/rust-clippy/master/index.html#doc_lazy_continuation)
+//
+// To achieve this, I can call call this function like follows:
+//
+//	var clippyTomlAsString := `
+//	disallowed-macros = ["std::println"]
+//	disallowed-methods = ["std::ptr::read"]
+//	`
+//	lintLevelModifications := []string{"#[allow(clippy::doc_lazy_continuation)]"}
+//
+//	if err := allowedItems.Check(exercise, clippyTomlAsString, lintLevelModifications); err != nil {
+//		// err != nil -> linting failed, meaning the submission did not pass your static analysis.
+//		// err.Error() will contain all necessary information for your trace, such as which line posed an issue,
+//		// which disallowed item(s) was/were found, (...), you can simply handle this as follows:
+//		return Exercise.CompilationError(err.Error())
+//	}
+//
+// See https://rust-lang.github.io/rust-clippy/master/index.html for details.
+func Check(exercise Exercise.Exercise, clippyTomlAsString string, lintLevelModifications []string) (err error) {
+	for _, filePath := range exercise.TurnInFiles {
+		if strings.Contains(filePath, ".rs") {
+			if err = prependLintLevel(filePath, lintLevelModifications); err != nil {
+				return err
+			}
+		}
+	}
+	file, err := os.Create(filepath.Join("studentcode", exercise.TurnInDirectory, ".clippy.toml"))
 	if err != nil {
 		return err
 	}
 	if _, err = file.WriteString(clippyTomlAsString); err != nil {
 		return err
 	}
-	workingDirectory := filepath.Join("compile-environment", exercise.TurnInDirectory)
-	if output, err := testutils.RunCommandLine(workingDirectory, "cargo", []string{"clippy", "--", "-D", "warnings"}); err != nil {
-		
+	workingDirectory := filepath.Join("studentcode", exercise.TurnInDirectory)
+	if _, err := testutils.RunCommandLine(workingDirectory, "cargo", []string{"clippy", "--", "-D", "warnings"}); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/tests/R06/ex00.go
+++ b/internal/tests/R06/ex00.go
@@ -2,6 +2,7 @@ package R06
 
 import (
 	"path/filepath"
+	"rust-piscine/internal/alloweditems"
 
 	Exercise "github.com/42-Short/shortinette/pkg/interfaces/exercise"
 	"github.com/42-Short/shortinette/pkg/logger"
@@ -67,6 +68,9 @@ mod shortinette_tests_rust_0600 {
 `
 
 func ex00Test(exercise *Exercise.Exercise) Exercise.Result {
+	if err := alloweditems.Execute(*exercise); err != nil {
+		return Exercise.CompilationError(err.Error())
+	}
 	workingDirectory := filepath.Join(exercise.RepoDirectory, exercise.TurnInDirectory)
 	if err := testutils.AppendStringToFile(tests00, exercise.TurnInFiles[0]); err != nil {
 		logger.Exercise.Printf("could not write to %s: %v", exercise.TurnInFiles[0], err)

--- a/internal/tests/R06/ex00.go
+++ b/internal/tests/R06/ex00.go
@@ -68,7 +68,7 @@ mod shortinette_tests_rust_0600 {
 `
 
 func ex00Test(exercise *Exercise.Exercise) Exercise.Result {
-	if err := alloweditems.Execute(*exercise); err != nil {
+	if err := alloweditems.Execute(*exercise, ""); err != nil {
 		return Exercise.CompilationError(err.Error())
 	}
 	workingDirectory := filepath.Join(exercise.RepoDirectory, exercise.TurnInDirectory)

--- a/internal/tests/R06/ex00.go
+++ b/internal/tests/R06/ex00.go
@@ -67,8 +67,12 @@ mod shortinette_tests_rust_0600 {
 }
 `
 
+var clippyTomlAsString00 = `
+disallowed-methods = ["std::ptr::read"]
+`
+
 func ex00Test(exercise *Exercise.Exercise) Exercise.Result {
-	if err := alloweditems.Execute(*exercise, ""); err != nil {
+	if err := alloweditems.Check(*exercise, clippyTomlAsString00, []string{"#[allow(clippy::doc_lazy_continuation)]"}); err != nil {
 		return Exercise.CompilationError(err.Error())
 	}
 	workingDirectory := filepath.Join(exercise.RepoDirectory, exercise.TurnInDirectory)


### PR DESCRIPTION
[cargo clippy](https://rust-lang.github.io/rust-clippy/master/index.html) allows custom linting of Rust code through the compiler's AST, which simplifies the task of banning functions/macros a LOT.